### PR TITLE
fixed recyclerview span count

### DIFF
--- a/app/src/main/java/ani/saikou/anime/AnimeWatchFragment.kt
+++ b/app/src/main/java/ani/saikou/anime/AnimeWatchFragment.kt
@@ -30,27 +30,31 @@ import kotlin.math.roundToInt
 
 
 open class AnimeWatchFragment : Fragment() {
-    open val sources : Sources = AnimeSources
+    open val sources: Sources = AnimeSources
     private var _binding: FragmentAnimeWatchBinding? = null
     private val binding get() = _binding!!
-    private val model : MediaDetailsViewModel by activityViewModels()
+    private val model: MediaDetailsViewModel by activityViewModels()
 
-    private lateinit var media : Media
+    private lateinit var media: Media
 
     private var start = 0
-    private var end : Int? = null
+    private var end: Int? = null
     private var style = 0
     private var reverse = false
 
-    private lateinit  var headerAdapter: AnimeWatchAdapter
-    private lateinit  var episodeAdapter: EpisodeAdapter
+    private lateinit var headerAdapter: AnimeWatchAdapter
+    private lateinit var episodeAdapter: EpisodeAdapter
 
     private var screenWidth = 0f
     private var progress = View.VISIBLE
 
-    var continueEp:Boolean=false
+    var continueEp: Boolean = false
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         _binding = FragmentAnimeWatchBinding.inflate(inflater, container, false)
         return _binding?.root
     }
@@ -58,39 +62,43 @@ open class AnimeWatchFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.animeSourceRecycler.updatePadding(bottom = binding.animeSourceRecycler.paddingBottom + navBarHeight)
-        screenWidth=resources.displayMetrics.widthPixels.dp
+        screenWidth = resources.displayMetrics.widthPixels.dp
 
-        val maxGridSize=(screenWidth/200f).roundToInt()
-        val gridLayoutManager = GridLayoutManager(requireContext(),maxGridSize)
+        val maxGridSize = (screenWidth / 200f).roundToInt()
+        val gridLayoutManager = GridLayoutManager(requireContext(), maxGridSize)
+
         gridLayoutManager.spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
             override fun getSpanSize(position: Int): Int {
+                val style =
+                    binding.animeSourceRecycler.findViewHolderForAdapterPosition(position)?.itemViewType
+                        ?: style
                 return when (position) {
                     0 -> maxGridSize
-                    else -> when (style){
-                        0->maxGridSize
-                        1->(maxGridSize.toFloat()/3).roundToInt()
-                        2->1
-                        else->maxGridSize
+                    else -> when (style) {
+                        0 -> maxGridSize
+                        1 -> (maxGridSize.toFloat() / 3).roundToInt()
+                        2 -> 1
+                        else -> maxGridSize
                     }
                 }
             }
         }
 
-        binding.animeSourceRecycler.layoutManager =gridLayoutManager
-        continueEp = model.continueMedia?:false
-        model.getMedia().observe(viewLifecycleOwner){
-            if(it!=null){
+        binding.animeSourceRecycler.layoutManager = gridLayoutManager
+        continueEp = model.continueMedia ?: false
+        model.getMedia().observe(viewLifecycleOwner) {
+            if (it != null) {
                 media = it
                 media.selected = model.loadSelected(media.id)
                 progress = View.GONE
                 binding.mediaInfoProgressBar.visibility = progress
 
-                model.watchSources = if(media.isAdult) HSources else AnimeSources
+                model.watchSources = if (media.isAdult) HSources else AnimeSources
 
-                headerAdapter = AnimeWatchAdapter(it,this,sources)
-                episodeAdapter = EpisodeAdapter(style,media,this)
+                headerAdapter = AnimeWatchAdapter(it, this, sources)
+                episodeAdapter = EpisodeAdapter(style, media, this)
 
-                binding.animeSourceRecycler.adapter = ConcatAdapter(headerAdapter,episodeAdapter)
+                binding.animeSourceRecycler.adapter = ConcatAdapter(headerAdapter, episodeAdapter)
 
                 model.getEpisodes().observe(viewLifecycleOwner) { loadedEpisodes ->
                     if (loadedEpisodes != null) {
@@ -100,14 +108,16 @@ open class AnimeWatchFragment : Fragment() {
                                 if (media.anime?.fillerEpisodes != null) {
                                     if (media.anime!!.fillerEpisodes!!.containsKey(i)) {
                                         episode.title = media.anime!!.fillerEpisodes!![i]?.title
-                                        episode.filler = media.anime!!.fillerEpisodes!![i]?.filler ?: false
+                                        episode.filler =
+                                            media.anime!!.fillerEpisodes!![i]?.filler ?: false
                                     }
                                 }
                                 if (media.anime?.kitsuEpisodes != null) {
                                     if (media.anime!!.kitsuEpisodes!!.containsKey(i)) {
                                         episode.desc = media.anime!!.kitsuEpisodes!![i]?.desc
                                         episode.title = media.anime!!.kitsuEpisodes!![i]?.title
-                                        episode.thumb = media.anime!!.kitsuEpisodes!![i]?.thumb ?: media.cover
+                                        episode.thumb =
+                                            media.anime!!.kitsuEpisodes!![i]?.thumb ?: media.cover
                                     }
                                 }
                             }
@@ -118,20 +128,26 @@ open class AnimeWatchFragment : Fragment() {
                             val divisions = total.toDouble() / 10
                             start = 0
                             end = null
-                            val limit = when{
+                            val limit = when {
                                 (divisions < 25) -> 25
                                 (divisions < 50) -> 50
                                 else -> 100
                             }
                             headerAdapter.clearChips()
-                            if (total>limit) {
+                            if (total > limit) {
                                 val arr = media.anime!!.episodes!!.keys.toTypedArray()
                                 val stored = ceil((total).toDouble() / limit).toInt()
-                                val position = clamp(media.selected!!.chip,0,stored-1)
-                                val last = if (position+1 == stored) total else (limit * (position+1))
+                                val position = clamp(media.selected!!.chip, 0, stored - 1)
+                                val last =
+                                    if (position + 1 == stored) total else (limit * (position + 1))
                                 start = limit * (position)
-                                end = last-1
-                                headerAdapter.updateChips(limit,arr,(1..stored).toList().toTypedArray(),position)
+                                end = last - 1
+                                headerAdapter.updateChips(
+                                    limit,
+                                    arr,
+                                    (1..stored).toList().toTypedArray(),
+                                    position
+                                )
                             }
                             reload()
                         }
@@ -145,7 +161,7 @@ open class AnimeWatchFragment : Fragment() {
                     media.anime?.fillerEpisodes = i
                 }
 
-                lifecycleScope.launch(Dispatchers.IO){
+                lifecycleScope.launch(Dispatchers.IO) {
                     awaitAll(
                         async { model.loadKitsuEpisodes(media) },
                         async { model.loadFillerEpisodes(media) }
@@ -156,7 +172,7 @@ open class AnimeWatchFragment : Fragment() {
         }
     }
 
-    fun onSourceChange(i:Int):LiveData<String>{
+    fun onSourceChange(i: Int): LiveData<String> {
         media.anime?.episodes = null
         reload()
         val selected = model.loadSelected(media.id)
@@ -167,16 +183,16 @@ open class AnimeWatchFragment : Fragment() {
         return sources[i]!!.live
     }
 
-    fun onIconPressed(viewType:Int,rev:Boolean){
+    fun onIconPressed(viewType: Int, rev: Boolean) {
         media.selected!!.recyclerStyle = viewType
         media.selected!!.recyclerReversed = reverse
         model.saveSelected(media.id, media.selected!!, requireActivity())
-        style=viewType
+        style = viewType
         reverse = rev
         reload()
     }
 
-    fun onChipClicked(i:Int,s:Int,e:Int){
+    fun onChipClicked(i: Int, s: Int, e: Int) {
         media.selected!!.chip = i
         start = s
         end = e
@@ -184,26 +200,29 @@ open class AnimeWatchFragment : Fragment() {
         reload()
     }
 
-    fun onEpisodeClick(i:String){
+    fun onEpisodeClick(i: String) {
         model.continueMedia = false
-        model.onEpisodeClick(media,i,requireActivity().supportFragmentManager)
+        model.onEpisodeClick(media, i, requireActivity().supportFragmentManager)
     }
 
     @SuppressLint("NotifyDataSetChanged")
-    private fun reload(){
+    private fun reload() {
         val selected = model.loadSelected(media.id)
-        model.saveSelected(media.id,selected,requireActivity())
+        model.saveSelected(media.id, selected, requireActivity())
         headerAdapter.handleEpisodes()
-        episodeAdapter.notifyItemRangeRemoved(0,episodeAdapter.arr.size)
-        var arr : ArrayList<Episode> = arrayListOf()
-        if(media.anime!!.episodes!=null) {
+        episodeAdapter.notifyItemRangeRemoved(0, episodeAdapter.arr.size)
+        var arr: ArrayList<Episode> = arrayListOf()
+        if (media.anime!!.episodes != null) {
             val end = if (end != null && end!! < media.anime!!.episodes!!.size) end else null
-            arr.addAll(media.anime!!.episodes!!.values.toList().slice(start..(end ?: (media.anime!!.episodes!!.size - 1))))
+            arr.addAll(
+                media.anime!!.episodes!!.values.toList()
+                    .slice(start..(end ?: (media.anime!!.episodes!!.size - 1)))
+            )
             arr = if (reverse) arr.reversed() as ArrayList<Episode> else arr
         }
         episodeAdapter.arr = arr
         episodeAdapter.type = style
-        episodeAdapter.notifyItemRangeInserted(0,arr.size)
+        episodeAdapter.notifyItemRangeInserted(0, arr.size)
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/ani/saikou/anime/EpisodeAdapters.kt
+++ b/app/src/main/java/ani/saikou/anime/EpisodeAdapters.kt
@@ -48,11 +48,15 @@ class EpisodeAdapter(
         }
     }
 
+    override fun getItemViewType(position: Int): Int {
+        return type
+    }
+
     @SuppressLint("SetTextI18n")
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        when {
-            holder is EpisodeCompactViewHolder->{
-                val binding = (holder as EpisodeCompactViewHolder).binding
+        when (holder) {
+            is EpisodeCompactViewHolder -> {
+                val binding = holder.binding
                 setAnimation(fragment.requireContext(),holder.binding.root)
                 val ep = arr[position]
                 binding.itemEpisodeNumber.text = ep.number
@@ -69,8 +73,8 @@ class EpisodeAdapter(
                 }
                 handleProgress(binding.itemEpisodeProgressCont,binding.itemEpisodeProgress,binding.itemEpisodeProgressEmpty,media.id,ep.number)
             }
-            holder is EpisodeGridViewHolder->{
-                val binding = (holder as EpisodeGridViewHolder).binding
+            is EpisodeGridViewHolder -> {
+                val binding = holder.binding
                 setAnimation(fragment.requireContext(), binding.root)
                 val ep = arr[position]
                 Picasso.get().load(ep.thumb ?: media.cover).resize(400, 0)
@@ -103,7 +107,7 @@ class EpisodeAdapter(
                     ep.number
                 )
             }
-            holder is EpisodeListViewHolder->{
+            is EpisodeListViewHolder -> {
                 val binding = (holder as EpisodeListViewHolder).binding
                 setAnimation(fragment.requireContext(),holder.binding.root)
                 val ep = arr[position]
@@ -123,8 +127,7 @@ class EpisodeAdapter(
                     if (ep.number.toFloatOrNull()?:9999f<=media.userProgress!!.toFloat()) {
                         binding.root.alpha = 0.66f
                         binding.itemEpisodeViewed.visibility = View.VISIBLE
-                    }
-                    else{
+                    } else{
                         binding.root.alpha=1f
                         binding.itemEpisodeViewed.visibility = View.GONE
                         binding.root.setOnLongClickListener{


### PR DESCRIPTION
The real change being 
```kotlin
                val style =
                    binding.animeSourceRecycler.findViewHolderForAdapterPosition(position)?.itemViewType
                        ?: style
```
and 
```kotlin
    override fun getItemViewType(position: Int): Int {
        return type
    }
```
Using var for style and not even looking at the recyclerview is begging for bugs. I'd say it's better to read the state from a view than assume its state because android can always fuck up, like if onResume restores the view but not the appropriate variables :shrug: 

Though this code also makes the layoutmanager dependent on the recyclerview, so be aware.