### PR TITLE
Allow users to copy video URL

### DIFF
--- a/app/src/main/java/ani/saikou/anime/SelectorDialogFragment.kt
+++ b/app/src/main/java/ani/saikou/anime/SelectorDialogFragment.kt
@@ -248,6 +248,11 @@ class SelectorDialogFragment : BottomSheetDialogFragment() {
                     }
                     startExoplayer(media!!)
                 }
+                itemView.setOnLongClickListener {
+                    val url = extractor.videos[position].url.url
+                    copyToClipboard(url, false)
+                    toastString("Copied video URL to clipboard"); true
+                }
             }
         }
     }


### PR DESCRIPTION
This PR allows users to copy the video URL to download it using an external download manager.

There is an issue where the toast would be behind the card view, if anyone knows how to fix it please do so.
[video](https://user-images.githubusercontent.com/70033559/174080747-183050cf-7ad9-4bfc-9b42-39f3883188ec.mp4)