### PR TITLE
feat: Kamyroll Subtitle Language Change

### DIFF
--- a/app/src/main/java/ani/saikou/parsers/anime/Kamyroll.kt
+++ b/app/src/main/java/ani/saikou/parsers/anime/Kamyroll.kt
@@ -1,10 +1,9 @@
 package ani.saikou.parsers.anime
 
-import ani.saikou.FileUrl
-import ani.saikou.client
-import ani.saikou.levenshtein
+import ani.saikou.*
 import ani.saikou.media.Media
 import ani.saikou.parsers.*
+import ani.saikou.settings.PlayerSettings
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -208,9 +207,21 @@ class Kamyroll : AnimeParser() {
     }
 
     companion object {
+        private val player = "player_settings"
+        val settings = loadData<PlayerSettings>(player, toast = false) ?: PlayerSettings().apply { saveData(player, this) }
+        private val locale = when(settings.locale) {
+            0 -> "en-US"
+            1 -> "es-ES"
+            2 -> "pt-PT"
+            3 -> "pt-BR"
+            4 -> "fr-FR"
+            5 -> "de-DE"
+            6 -> "ar-ME"
+            7 -> "ru-RU"
+            else -> "en-US"
+        }
         private const val apiUrl = "https://kamyroll.herokuapp.com"
         private const val channel = "crunchyroll"
-        private const val locale = "en-US"
         private const val service = "google"
 
         private var headers: Map<String, String>? = null

--- a/app/src/main/java/ani/saikou/settings/PlayerSettings.kt
+++ b/app/src/main/java/ani/saikou/settings/PlayerSettings.kt
@@ -12,6 +12,7 @@ data class PlayerSettings(
     var secondaryColor: Int = 0,
     var outline: Int = 0,
     var font: Int = 0,
+    var locale: Int = 0,
 
     //Auto
     var autoPlay: Boolean = true,

--- a/app/src/main/java/ani/saikou/settings/PlayerSettingsActivity.kt
+++ b/app/src/main/java/ani/saikou/settings/PlayerSettingsActivity.kt
@@ -12,6 +12,7 @@ import androidx.core.widget.addTextChangedListener
 import ani.saikou.*
 import ani.saikou.databinding.ActivityPlayerSettingsBinding
 import kotlin.math.roundToInt
+import kotlin.system.exitProcess
 
 
 class PlayerSettingsActivity : AppCompatActivity() {
@@ -220,6 +221,16 @@ class PlayerSettingsActivity : AppCompatActivity() {
                 settings.font = count4
                 saveData(player, settings)
                 dialog.dismiss()
+            }.show()
+        }
+        val locales = arrayOf("[en-US] English", "[es-ES] Spanish", "[pt-PT] Portuguese", "[pt-BR] Brazilian Portuguese", "[fr-FR] French", "[de-DE] German", "[ar-ME] Arabic", "[ru-RU] Russian")
+        val localeDialog = AlertDialog.Builder(this, R.style.DialogTheme).setTitle("Subtitle Language")
+        binding.subLang.setOnClickListener {
+            localeDialog.setSingleChoiceItems(locales, settings.locale) { dialog, count5 ->
+                settings.locale = count5
+                saveData(player, settings)
+                dialog.dismiss()
+                exitProcess(0)
             }.show()
         }
     }

--- a/app/src/main/res/drawable/ic_round_translate_variant_24.xml
+++ b/app/src/main/res/drawable/ic_round_translate_variant_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11 1H3C1.9 1 1 1.9 1 3V15L4 12H9V11C9 8.8 10.79 7 13 7V3C13 1.9 12.1 1 11 1M11 4L9.5 4C9.16 5.19 8.54 6.3 7.68 7.26L7.66 7.28L8.92 8.53L8.55 9.54L7 8L4.5 10.5L3.81 9.77L6.34 7.28C5.72 6.59 5.22 5.82 4.86 5H5.85C6.16 5.6 6.54 6.17 7 6.68C7.72 5.88 8.24 4.97 8.57 4L3 4V3H6.5V2H7.5V3H11V4M21 9H13C11.9 9 11 9.9 11 11V18C11 19.1 11.9 20 13 20H20L23 23V11C23 9.9 22.1 9 21 9M19.63 19L18.78 16.75H15.22L14.38 19H12.88L16.25 10H17.75L21.13 19H19.63M17 12L18.22 15.25H15.79L17 12Z"/>
+</vector>

--- a/app/src/main/res/layout/activity_player_settings.xml
+++ b/app/src/main/res/layout/activity_player_settings.xml
@@ -377,6 +377,37 @@
                 android:text="@string/sub_color_info"
                 android:textSize="14sp" />
 
+            <Button
+                android:id="@+id/subLang"
+                style="@style/Widget.Material3.Button.TextButton"
+                android:layout_width="match_parent"
+                android:layout_height="64dp"
+                android:layout_marginBottom="8dp"
+                android:fontFamily="@font/poppins_bold"
+                android:insetTop="0dp"
+                android:insetBottom="0dp"
+                android:paddingStart="32dp"
+                android:paddingEnd="32dp"
+                android:text="@string/subtitle_language_button"
+                android:textAlignment="viewStart"
+                android:textAllCaps="false"
+                android:textColor="@color/bg_opp"
+                app:cornerRadius="0dp"
+                app:icon="@drawable/ic_round_translate_variant_24"
+                app:iconPadding="16dp"
+                app:iconSize="24dp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:alpha="0.58"
+                android:fontFamily="@font/poppins_family"
+                android:paddingStart="32dp"
+                android:paddingEnd="32dp"
+                android:text="@string/subtitle_language_info"
+                android:textSize="14sp" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -185,6 +185,8 @@
     <string name="secondary_sub_outline_type_select">Set Outline Type</string>
     <string name="sub_color_info"><b>Note:</b> Changing Subtitle formatting only work with Zoro!</string>
     <string name="sub_font_select">Subtitle Font</string>
+    <string name="subtitle_language_button">Subtitle Language</string>
+    <string name="subtitle_language_info"><b>Note:</b> The Subtitle-language can only be changed for <b>Kamyroll</b>. The change will restart the app.</string>
 
     <string name="auto">Auto</string>
     <string name="auto_play_next_episode">Autoplay Next Episode</string>


### PR DESCRIPTION
Adds a new button to change Kamyroll's subtitle, and as a side effect episode names, to the chosen language.
The button can be found in the player settings.

Currently available languages (I think i got all that Kamyroll supports):
- [en-US] English
- [es-ES] Spanish
- [pt-PT] Portuguese
- [pt-BR] Brazilian Portuguese
- [fr-FR] French
- [de-DE] German
- [ar-ME] Arabic
- [ru-RU] Russian

Preview:
![image](https://user-images.githubusercontent.com/39769465/179350022-6f4cf2f3-57b3-434c-b7ea-c5270e0abb4f.png)
![image](https://user-images.githubusercontent.com/39769465/179350032-5f9a29c9-bb03-49a4-85c1-32d1ac936e61.png)

