### PR TITLE
change: subtitle selector use regex to distinguish between locale and language name

### DIFF
--- a/app/src/main/java/ani/saikou/anime/SubtitleDialogFragment.kt
+++ b/app/src/main/java/ani/saikou/anime/SubtitleDialogFragment.kt
@@ -87,7 +87,7 @@ class SubtitleDialogFragment : BottomSheetDialogFragment() {
                     "pl-PL" -> "[pl-PL] Polish"
                     "ro-RO" -> "[ro-RO] Romanian"
                     "sv-SE" -> "[sv-SE] Swedish"
-                    else -> "[${subtitles[position - 1].language}]"
+                    else -> if(subtitles[position - 1].language matches Regex("([a-z]{2})-([A-Z]{2}|\\d{3})")) "[${subtitles[position - 1].language}]" else subtitles[position - 1].language
                 }
                 model.getMedia().observe(viewLifecycleOwner) { media ->
                     val mediaID: Int = media.id


### PR DESCRIPTION
This is a fix intended for zoro and future sources with separate subtitles, to hide the `[ ]` brackets, locale will still be in brackets (for example `en-US` -> `[en-US]`, and with matching language found `[en-US] English`)
Before:

![image](https://user-images.githubusercontent.com/39769465/196922982-4b7c03a2-8fd7-4325-b854-3927f32bab90.png)

After:

![image](https://user-images.githubusercontent.com/39769465/196922195-bd8dfc3a-7b37-4764-a2d2-10e3ecf95da2.png)
