### PR TITLE
Sort media by 'unseen' count.

### DIFF
--- a/app/src/main/java/ani/saikou/anilist/AnilistQueries.kt
+++ b/app/src/main/java/ani/saikou/anilist/AnilistQueries.kt
@@ -379,6 +379,15 @@ class AnilistQueries {
                 "updatedAt" -> sorted[i]?.sortWith(compareByDescending { it.userUpdatedAt })
                 "release"   -> sorted[i]?.sortWith(compareByDescending { it.startDate })
                 "id"        -> sorted[i]?.sortWith(compareBy { it.id })
+                "unseenCount" -> sorted[i]?.sortWith(compareBy {
+                    var diff = 0
+                    if (it.anime != null) {
+                        diff = (it.anime.nextAiringEpisode ?: it.anime.totalEpisodes ?: 0) - (it.userProgress ?: 0)
+                    } else if (it.manga != null) {
+                        diff = (it.manga.totalChapters ?: 0) - (it.userProgress ?: 0)
+                    }
+                    if (diff == 0) Int.MAX_VALUE else diff
+                })
             }
         }
         return sorted

--- a/app/src/main/java/ani/saikou/user/ListActivity.kt
+++ b/app/src/main/java/ani/saikou/user/ListActivity.kt
@@ -74,6 +74,7 @@ class ListActivity : AppCompatActivity() {
                    R.id.title -> "title"
                    R.id.updated -> "updatedAt"
                    R.id.release -> "release"
+                   R.id.unseenCount -> "unseenCount"
                    else -> null
                }
 

--- a/app/src/main/res/menu/list_sort_menu.xml
+++ b/app/src/main/res/menu/list_sort_menu.xml
@@ -12,4 +12,7 @@
     <item
         android:id="@+id/updated"
         android:title="@string/sort_by_last_updated" />
+    <item
+        android:id="@+id/unseenCount"
+        android:title="@string/sort_by_unseen_count" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,7 @@
     <string name="sort_by_title">Sort by Title</string>
     <string name="sort_by_last_updated">Sort by Last Updated</string>
     <string name="sort_by_score">Sort by Score</string>
+    <string name="sort_by_unseen_count">Sort by Unseen</string>
     <string name="over_scroll">Over Scroll to Next/Previous Chapter</string>
     <string name="volume_buttons">Change pages with Volume Buttons</string>
     <string name="list_private">Private</string>


### PR DESCRIPTION
# Description
This pull request adds an option for sorting media by an 'unseen' count (total - progress). In the case where the user is 'caught up' (unseenCount is 0) on an anime, this anime will appear at the end of the sorting (unseenCount is considered as Int.MAX_VALUE).
# Use Case
This sorting is useful primarily in the case where a user wants to manage many currently releasing anime and 'catch up' or complete anime in the order of least remaining episodes. 
# How to use
Navigate from the home page to either the user's manga list or anime list page. On this page, open the filter drop-down from the top right of the screen and select 'Sort by Unseen'.
# Modified files
- saikou\app\src\main\java\ani\saikou\anilist\AnilistQueries.kt
- saikou\app\src\main\java\ani\saikou\user\ListActivity.kt
- saikou\app\src\main\res\menu\list_sort_menu.xml
- saikou\app\src\main\res\values\strings.xml
# Issues
There doesn't seem to be a reliable way to get the number of currently released manga so the manga uses totalChapters exclusively.